### PR TITLE
Align example with recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Contributions are welcome via Issues and Pull Requests.
     (str "Processing: " coll)))
 
 (defn process-if-empty [coll]
-  (when (= 0 (count coll))
+  (when (seq coll)
     "Empty collection detected"))
 
 [(process-if-not-empty [])


### PR DESCRIPTION
The recommendation written here is correct, which is to use `seq` 

"Using `seq` not only simplifies the check but also aligns with Clojure’s idiomatic style"

However the example uses `=` and `count`, not `seq`.

Also see the `doc` in the repl:
```
user=> (doc empty?)
-------------------------
clojure.core/empty?
([coll])
  Returns true if coll has no items - same as (not (seq coll)).
  Please use the idiom (seq x) rather than (not (empty? x))
```